### PR TITLE
Fixing livereload bug with browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Just override any Ionic variables in `app/styles/ionic-styles.scss`.
 
 ## Changelog
 
+#### 1.3.3
+- bugfix for infinite livereload when using browserify
+
 #### 1.3.2
 - added optional browserify support
 

--- a/app/templates/_gulpfile.browserify.js
+++ b/app/templates/_gulpfile.browserify.js
@@ -324,11 +324,11 @@ gulp.task('watchers', function() {
   gulp.watch('app/fonts/**', ['fonts']);
   gulp.watch('app/icons/**', ['iconfont']);
   gulp.watch('app/images/**', ['images']);
-  gulp.watch('app/scripts/**/*.js', ['index']);
+  gulp.watch(['app/scripts/**/*.js','!app/scripts/bundle.js'], ['index']);
   gulp.watch('./vendor.json', ['vendor']);
   gulp.watch('app/templates/**/*.html', ['index']);
   gulp.watch('app/index.html', ['index']);
-  gulp.watch('app/src/**/*.js', ['browserify']);
+  gulp.watch('app/src/**/*.js', ['scripts']);
   gulp.watch(targetDir + '/**')
     .on('change', plugins.livereload.changed)
     .on('error', errorHandler);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ionic-gulp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A Yeoman generator for Ionic projects with gulp",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
I found an infinite reload problem with live reload when using browserify. The bundle.js was not properly excluded from the gulp watches. I've amended the gulpfile and bumped the version for the fix.

Sorry this one slipped past me.
