### PR TITLE
Fixed bundle.js not being gitignored

### DIFF
--- a/app/templates/gitignore.browserify
+++ b/app/templates/gitignore.browserify
@@ -12,5 +12,5 @@ www/
 *.DS_Store
 *.log
 
-scripts/bundle.js
-scripts/bundle.js.map
+app/scripts/bundle.js
+app/scripts/bundle.js.map


### PR DESCRIPTION
I'm trying to cut down on pull requests, honest!

Small oversight in the gitignore pattern meant the bundle.js file was ending up in the git repo. Merge at your leisure.
