### PR TITLE
Add babelify for transpiling to ES6 duringb browserification

### DIFF
--- a/app/templates/_gulpfile.browserify.js
+++ b/app/templates/_gulpfile.browserify.js
@@ -22,6 +22,7 @@ var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var gutil = require('gulp-util');
 var wiredep = require('wiredep');
+var babel = require('babelify');
 
 /**
  * Parse arguments
@@ -107,7 +108,7 @@ gulp.task('browserify', function () {
   var b = browserify({
     entries: './app/src/app.js',
     debug: !build
-  });
+  }).transform('babelify', {presets: ['es2015']});
 
   return b.bundle()
     .pipe(source('bundle.js'))

--- a/app/templates/_package.browserify.json
+++ b/app/templates/_package.browserify.json
@@ -5,6 +5,8 @@
   "description": "",
   "dependencies": {},
   "devDependencies": {
+    "babel-preset-es2015": "^6.14.0",
+    "babelify": "^7.3.0",
     "beepbeep": "^1.2.0",
     "connect-livereload": "^0.5.2",
     "del": "^2.2.0",


### PR DESCRIPTION
This PR doesn't include ES6 transpiling for users who opt out of Browserify.
